### PR TITLE
Fix FIND-PORT function

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,35 @@
+# .github/workflows/test.yaml
+name: test
+on: [ push, pull_request ]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        implementation:
+          - sbcl
+          - ecl
+          - ccl
+        include:
+          - implementation: sbcl
+            image: clfoundation/sbcl:2.2.4
+            command: sbcl
+          - implementation: ecl
+            image: clfoundation/ecl:21.2.1
+            command: ecl
+          - implementation: ccl
+            image: clfoundation/ccl:1.12
+            command: ccl
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+      env:
+        CI_SYSTEM: github
+        QUICKLISP_ADD_TO_INIT_FILE: true
+        QUICKLISP_DIST_VERSION: latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: |
+          env LISP=${{ matrix.command }} ./scripts/run-ci-tests.sh

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Runs the CI tests
+#
+
+set -e
+
+SCRIPTS_DIR=$( dirname `readlink -f -- "${0}"` )
+SYSTEMS_DIR=$( dirname "${SCRIPTS_DIR}" )
+ASDF_SOURCE_REGISTRY=~/.config/common-lisp/source-registry.conf.d
+
+if [ -z "${CI_SYSTEM}" ]; then
+    echo "Script does not seem to be invoked from a CI system, exiting."
+    exit 1
+fi
+
+# Install Quicklisp
+/usr/local/bin/install-quicklisp
+
+# Configure ASDF, so that it finds our systems
+mkdir -p "${ASDF_SOURCE_REGISTRY}"
+echo "(:tree \"${SYSTEMS_DIR}\")" > "${ASDF_SOURCE_REGISTRY}/workspace.conf"
+
+${SCRIPTS_DIR}/run-tests.sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -e
+
+LISP=${LISP:-sbcl}
+
+${LISP} --eval '(ql:quickload :find-port-test)' \
+        --eval '(uiop:quit)'

--- a/src/find-port.lisp
+++ b/src/find-port.lisp
@@ -20,5 +20,4 @@
 
 (defun find-port (&key (min 40000) (max 50000) (interface *default-interface*))
   "Return the first available port in a range of port numbers."
-  (loop for port from min to max until (port-open-p port :interface interface)
-        finally (return port)))
+  (loop :for port :from min :to max :when (port-open-p port :interface interface) :return port))


### PR DESCRIPTION
The FIND-PORT function may not find an available port from the given
range, but will return the last value of PORT variable, instead of NIL
which would indicate that no port in the range is available.

The change fixes that behaviour, so that NIL is returned when no ports
in the range is available.